### PR TITLE
feat: Adding an option to make header sticky

### DIFF
--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -1,6 +1,7 @@
 <template>
   <header class="header">
     <nav
+      :class="isSticky ? 'is-fixed-top' : ''"
       class="navbar is-dark-ben-franklin"
       role="navigation"
       aria-label="main navigation"
@@ -41,7 +42,7 @@
             </a>
           </div>
 
-          <slot name="mobile-menu"></slot>
+          <slot name="mobile-menu" />
         </div>
 
         <div class="navbar-menu is-hidden-mobile">
@@ -88,11 +89,15 @@ export default {
       type: Boolean,
       default: true,
     },
+    isSticky: {
+      type: Boolean,
+      default: false,
+    },
   },
 };
 </script>
 <style lang="scss" scoped>
-  .header {
+  .header > nav {
     border-bottom: 5px solid $electric-blue;
   }
   .navbar {

--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -2,7 +2,7 @@
   <header class="header">
     <nav
       :class="isSticky ? 'is-fixed-top' : ''"
-      class="navbar is-dark-ben-franklin"
+      class="navbar main-nav is-dark-ben-franklin"
       role="navigation"
       aria-label="main navigation"
     >
@@ -97,7 +97,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-  .header > nav {
+  .header .main-nav {
     border-bottom: 5px solid $electric-blue;
   }
   .navbar {


### PR DESCRIPTION
Added "is-sticky" prop which uses bulma is-fixed-top class to make the header sticky. The default is set to "false". 
