### PR TITLE
Fix/vee radio

### DIFF
--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -52,7 +52,6 @@
             role="checkbox"
             v-bind="option.attrs || {}"
             :value="optionValue(option, value)"
-            @change="updateModelValue($event, optionValue(option, value))"
             v-on="inputListeners"
           >
           <label
@@ -118,7 +117,7 @@ export default {
     * @ignore
     */
     value: {
-      type: Array,
+      type: null,
       default () {
         return [];
       },
@@ -158,8 +157,17 @@ export default {
       return Object.assign({},
         this.$listeners,
         {
-          change: async function (event) {
+          change: function (event) {
+
+            //Updates the vmodel value before emitting it
+            vm.updateModelValue(event, event.target.value);
+
+            //IE11 needs the change event to be emitted as it does not listen to input
             vm.$emit('change', vm.modelValue);
+
+            //VeeValidate needs the input event to be emitted.
+            vm.$emit('input', vm.modelValue);
+
           },
         }
       );

--- a/src/components/Inputs/Radio/Radio.vue
+++ b/src/components/Inputs/Radio/Radio.vue
@@ -48,11 +48,11 @@
             :id="`rd-${key}-${id}`"
             type="radio"
             role="radio"
-            :aria-checked="modelValue === optionValue(option, key)"
+            :aria-checked="value === optionValue(option, key)"
             :name="`rd-${key}-${id}`"
             class="is-checkradio"
             :value="optionValue(option, key)"
-            :checked="modelValue === optionValue(option, key)"
+            :checked="value === optionValue(option, key)"
             v-bind="option.attrs || {}"
             v-on="inputListeners"
           >
@@ -80,10 +80,6 @@ export default {
     inputMixins,
   ],
   inheritAttrs: false,
-  model: {
-    prop: "modelValue",
-    event: "change",
-  },
   props: {
 
     /**
@@ -121,15 +117,7 @@ export default {
     * @ignore
     */
     value: {
-      type: String,
-      default: '',
-    },
-
-    /**
-    * @ignore
-    */
-    modelValue: {
-      type: String,
+      type: null,
       default: '',
     },
 
@@ -163,11 +151,14 @@ export default {
       return Object.assign({},
         this.$listeners,
         {
-          input: function (event) {
-            vm.$emit('input', event.target.value);
-          },
           change: function (event) {
+
+            //IE11 needs the change event to be emitted as it does not listen to input
             vm.$emit('change', event.target.value);
+
+            //VeeValidate needs the input event to be emitted.
+            vm.$emit('input', event.target.value);
+
           },
         }
       );


### PR DESCRIPTION
@alejandroxlopez I have 2 PR's addressing the same issue; one with the radio button and one with the checkbox.

Basically VeeValidate needs the input event to be emitted, while IE11 needs the change event to be emitted. I've added both as I have not been able to come up with a better solution. I believe you might have a better fix. Please review this. I've tested with IE11 and other browsers. If you have a better solution, please, feel free to share.