### PR TITLE
Fixes an issue with checkboxes and vee-validate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6906,7 +6906,8 @@
     },
     "chokidar": {
       "version": "2.1.8",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8808,8 +8809,12 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "dotenv": {
       "version": "8.2.0",
@@ -9405,7 +9410,8 @@
       "dependencies": {
         "acorn": {
           "version": "6.3.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
           "dev": true
         },
         "acorn-jsx": {
@@ -12145,6 +12151,12 @@
           }
         }
       }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "2.2.0",

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -113,11 +113,8 @@ export default {
       default: "",
     },
 
-    /**
-    * @ignore
-    */
     value: {
-      type: null,
+      type: [ Array ],
       default () {
         return [];
       },
@@ -153,6 +150,9 @@ export default {
   },
   computed: {
     inputListeners: function () {
+
+      delete this.$listeners['input'];
+
       var vm = this;
       return Object.assign({},
         this.$listeners,

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -51,7 +51,7 @@
             class="is-checkradio"
             role="checkbox"
             v-bind="option.attrs || {}"
-            :value="optionValue(option, value)"
+            :value="optionValue(option, key)"
             v-on="inputListeners"
           >
           <label
@@ -175,6 +175,7 @@ export default {
   },
   methods: {
     updateModelValue (event, value) {
+      console.log(value);
       if (event.target.checked) {
         if (this.options.length === 1) {
           this.modelValue = [ this.$attrs['true-value'] || value ];

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -52,7 +52,6 @@
             role="checkbox"
             v-bind="option.attrs || {}"
             :value="optionValue(option, value)"
-            @change="updateModelValue($event, optionValue(option, value))"
             v-on="inputListeners"
           >
           <label
@@ -118,7 +117,7 @@ export default {
     * @ignore
     */
     value: {
-      type: Array,
+      type: null,
       default () {
         return [];
       },
@@ -158,8 +157,17 @@ export default {
       return Object.assign({},
         this.$listeners,
         {
-          change: async function (event) {
+          change: function (event) {
+
+            //Updates the vmodel value before emitting it
+            vm.updateModelValue(event, event.target.value);
+
+            //IE11 needs the change event to be emitted as it does not listen to input
             vm.$emit('change', vm.modelValue);
+
+            //VeeValidate needs the input event to be emitted.
+            vm.$emit('input', vm.modelValue);
+
           },
         }
       );

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -175,7 +175,6 @@ export default {
   },
   methods: {
     updateModelValue (event, value) {
-      console.log(value);
       if (event.target.checked) {
         if (this.options.length === 1) {
           this.modelValue = [ this.$attrs['true-value'] || value ];


### PR DESCRIPTION
VeeValidate needs the input to be emitted so that wrapper pickups up the changes to the checkbox. However IE11 needs the 'change' event to be emitted. This fix addresses these 2 issues by emitting both under the change event. I've also set the 'value' prop type to null, because VeeValidate emits a type of 'Event' at first, which causes the prop type to fail if enforced.