### PR TITLE
docs: fixed path to 'edit on github'

### DIFF
--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -6,6 +6,6 @@
     "dark": "/city-of-philadelphia.svg"
   },
   "defaultDir": "docs",
-  "defaultBranch": "docs",
+  "defaultBranch": "master",
   "github": "CityOfPhiladelphia/phila-ui"
 }


### PR DESCRIPTION
this fixes the "Edit this page on GitHub" url in the docs... it was pointing to the wrong branch.