### PR TITLE
Fix/checkbox radio

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,0 +1,3 @@
+> 1%
+last 2 versions
+not dead

--- a/src/assets/styles/scss/inputs.scss
+++ b/src/assets/styles/scss/inputs.scss
@@ -167,6 +167,9 @@ form {
     }
 
     &.small-checkradio {
+      .control {
+        margin-bottom: .1rem;
+      }
       .is-checkradio[type=checkbox] + label {
         margin-left: 1.5rem;
         font-size: $size-small;

--- a/src/assets/styles/scss/inputs.scss
+++ b/src/assets/styles/scss/inputs.scss
@@ -184,7 +184,25 @@ form {
           left: -1.1rem !important;
         }
       }
+
+      .is-checkradio[type=radio] + label {
+        margin-left: 1.5rem !important;
+        font-size: $size-small;
+        &:before {
+          width: 1.125rem;
+          height: 1.125rem;
+          left: -1.5rem !important;
+          top: .18rem;
+        }
+        &:after {
+          transform: scale(0.3);
+          top: 0rem;
+          left: -1.7rem !important;
+        }
+      }
+
     }
+
 
     &.required {
       fieldset legend {

--- a/src/assets/styles/scss/inputs.scss
+++ b/src/assets/styles/scss/inputs.scss
@@ -166,6 +166,23 @@ form {
       }
     }
 
+    &.small-checkradio {
+      .is-checkradio[type=checkbox] + label {
+        margin-left: 1.5rem;
+        font-size: $size-small;
+        &:before {
+          width: 1.125rem;
+          height: 1.125rem;
+          left: -1.5rem !important;
+          top: .18rem;
+        }
+        &:after {
+          top: 0.3rem;
+          left: -1.1rem !important;
+        }
+      }
+    }
+
     &.required {
       fieldset legend {
         &:after {
@@ -204,6 +221,7 @@ form {
       left: -2rem !important;
     }
     .is-checkradio[type=checkbox] + label:after {
+      top: .3rem;
       left: -1.4rem !important;
     }
     .is-checkradio[type=radio] + label:after {

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -45,8 +45,8 @@
         >
           <input
             :id="`cb-${key}-${id}`"
+            v-model="localValue"
             :name="`cb-${key}-${id}`"
-            :aria-checked="modelValue.includes(optionValue(option, value))"
             type="checkbox"
             class="is-checkradio"
             role="checkbox"
@@ -78,10 +78,10 @@ export default {
     inputMixins,
   ],
   inheritAttrs: false,
-  model: {
-    prop: 'modelValue',
-    event: 'change',
-  },
+  // model: {
+  //   prop: 'modelValue',
+  //   event: 'change',
+  // },
   props: {
     /**
      * The checkboxes options.
@@ -145,7 +145,7 @@ export default {
   },
   data () {
     return {
-      modelValue: [],
+      localValue: this.value,
     };
   },
   computed: {
@@ -159,14 +159,14 @@ export default {
         {
           change: function (event) {
 
-            //Updates the vmodel value before emitting it
-            vm.updateModelValue(event, event.target.value);
+            // //Updates the vmodel value before emitting it
+            // vm.updateModelValue(event, event.target.value);
 
             //IE11 needs the change event to be emitted as it does not listen to input
-            vm.$emit('change', vm.modelValue);
+            vm.$emit('change', vm.localValue);
 
             //VeeValidate needs the input event to be emitted.
-            vm.$emit('input', vm.modelValue);
+            vm.$emit('input', vm.localValue);
 
           },
         }

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -183,6 +183,11 @@ export default {
       return this.classes;
     },
   },
+  watch: {
+    value (newValue) {
+      this.localValue = newValue;
+    },
+  },
 };
 </script>
 

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -48,6 +48,7 @@
             v-model="localValue"
             :name="`cb-${key}-${id}`"
             type="checkbox"
+            :aria-checked="value.includes(optionValue(option, key))"
             class="is-checkradio"
             role="checkbox"
             v-bind="option.attrs || {}"
@@ -78,10 +79,6 @@ export default {
     inputMixins,
   ],
   inheritAttrs: false,
-  // model: {
-  //   prop: 'modelValue',
-  //   event: 'change',
-  // },
   props: {
     /**
      * The checkboxes options.
@@ -127,6 +124,7 @@ export default {
       type: String,
       default: '',
     },
+
     /**
      * The description used for the checkbox or group of checkboxes
      */
@@ -144,13 +142,14 @@ export default {
     },
 
     /**
-     * Allows to pass bulma classes to checkbox input
+     * Use small checkboxes
      */
     small: {
       type: Boolean ,
       default: false,
     },
   },
+
   data () {
     return {
       localValue: this.value,
@@ -167,9 +166,6 @@ export default {
         {
           change: function (event) {
 
-            // //Updates the vmodel value before emitting it
-            // vm.updateModelValue(event, event.target.value);
-
             //IE11 needs the change event to be emitted as it does not listen to input
             vm.$emit('change', vm.localValue);
 
@@ -185,27 +181,6 @@ export default {
         return `${this.classes} small-checkradio`;
       }
       return this.classes;
-    },
-  },
-  methods: {
-    updateModelValue (event, value) {
-      if (event.target.checked) {
-        if (this.options.length === 1) {
-          this.modelValue = [ this.$attrs['true-value'] || value ];
-        } else {
-          this.modelValue.push(value);
-        }
-      } else {
-        if (this.options.length === 1) {
-          if (this.$attrs['false-value']) {
-            this.modelValue.push(this.$attrs['false-value']);
-          } else {
-            this.modelValue = [];
-          }
-        } else {
-          this.modelValue.splice(this.modelValue.indexOf(value), 1);
-        }
-      }
     },
   },
 };

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -169,7 +169,7 @@ export default {
             vm.$emit('input', vm.localValue);
 
           },
-        }
+        },
       );
     },
   },

--- a/src/components/Inputs/Checkbox/Checkbox.vue
+++ b/src/components/Inputs/Checkbox/Checkbox.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="input-wrap input-checkbox"
-    :class="classes"
+    :class="checkRadioClasses"
   >
     <fieldset>
       <legend>
@@ -142,6 +142,14 @@ export default {
       type: [ String, Number ],
       default: 1,
     },
+
+    /**
+     * Allows to pass bulma classes to checkbox input
+     */
+    small: {
+      type: Boolean ,
+      default: false,
+    },
   },
   data () {
     return {
@@ -171,6 +179,12 @@ export default {
           },
         },
       );
+    },
+    checkRadioClasses () {
+      if (this.small) {
+        return `${this.classes} small-checkradio`;
+      }
+      return this.classes;
     },
   },
   methods: {

--- a/src/components/Inputs/Radio/Radio.vue
+++ b/src/components/Inputs/Radio/Radio.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="input-wrap input-radio"
-    :class="classes"
+    :class="checkRadioClasses"
   >
     <fieldset>
       <legend>
@@ -46,6 +46,7 @@
         >
           <input
             :id="`rd-${key}-${id}`"
+            v-model="localValue"
             type="radio"
             role="radio"
             :aria-checked="value === optionValue(option, key)"
@@ -144,9 +145,32 @@ export default {
       type: [ String, Number ],
       default: 1,
     },
+
+    /**
+     * Use small radio buttons
+     */
+    small: {
+      type: Boolean ,
+      default: false,
+    },
+
+  },
+  data () {
+    return {
+      localValue: this.value,
+    };
   },
   computed: {
+    checkRadioClasses () {
+      if (this.small) {
+        return `${this.classes} small-checkradio`;
+      }
+      return this.classes;
+    },
     inputListeners: function () {
+
+      delete this.$listeners['input'];
+
       var vm = this;
       return Object.assign({},
         this.$listeners,
@@ -154,10 +178,10 @@ export default {
           change: function (event) {
 
             //IE11 needs the change event to be emitted as it does not listen to input
-            vm.$emit('change', event.target.value);
+            vm.$emit('change', vm.localValue);
 
             //VeeValidate needs the input event to be emitted.
-            vm.$emit('input', event.target.value);
+            vm.$emit('input', vm.localValue);
 
           },
         }

--- a/src/components/Inputs/Radio/Radio.vue
+++ b/src/components/Inputs/Radio/Radio.vue
@@ -53,7 +53,6 @@
             :name="`rd-${key}-${id}`"
             class="is-checkradio"
             :value="optionValue(option, key)"
-            :checked="value === optionValue(option, key)"
             v-bind="option.attrs || {}"
             v-on="inputListeners"
           >
@@ -184,8 +183,13 @@ export default {
             vm.$emit('input', vm.localValue);
 
           },
-        }
+        },
       );
+    },
+  },
+  watch: {
+    value (newValue) {
+      this.localValue = newValue;
     },
   },
 };


### PR DESCRIPTION
This PR does 2 things:
1. fixes how checkboxes and radio buttons were keeping track of the current value. It was emitting correctly but it was not letting the parent update it's value. This goes back to using localValue.

2. It introduces a "small" prop to allow for a smaller rendering of the checkboxes and radio buttons