### PR TITLE
adds optgroup to dropdown

### DIFF
--- a/src/components/Inputs/Dropdown/Dropdown.vue
+++ b/src/components/Inputs/Dropdown/Dropdown.vue
@@ -34,15 +34,34 @@
             <option value="">
               {{ this.$attrs.required !== undefined ? `${placeholder}*` : placeholder }}
             </option>
-            <option
-              v-for="(option, key) in options"
-              :key="key"
-              :value="optionValue(option, key)"
-              :selected="isSelected(key, option)"
-              :disabled="option['disabled'] ? option['disabled'] : false"
-            >
-              {{ !textKey ? option : option[textKey] }}
-            </option>
+            <template v-if="optgroup">
+              <optgroup
+                v-for="(groupValue, group) in options"
+                :key="group"
+                :label="group"
+              >
+                <option
+                  v-for="(option, key) in options[group]"
+                  :key="key"
+                  :value="optionValue(option, key)"
+                  :selected="isSelected(key, option)"
+                  :disabled="option['disabled'] ? option['disabled'] : false"
+                >
+                  {{ !textKey ? option : option[textKey] }}
+                </option>
+              </optgroup>
+            </template>
+            <template v-else>
+              <option
+                v-for="(option, key) in options"
+                :key="key"
+                :value="optionValue(option, key)"
+                :selected="isSelected(key, option)"
+                :disabled="option['disabled'] ? option['disabled'] : false"
+              >
+                {{ !textKey ? option : option[textKey] }}
+              </option>
+            </template>
           </select>
           <span
             v-if="icon"
@@ -169,6 +188,11 @@ export default {
       default: true,
     },
 
+    optgroup: {
+      type: Boolean,
+      defaults: false,
+    },
+
   },
   data () {
     return {
@@ -176,6 +200,25 @@ export default {
     };
   },
   computed: {
+    ungrouppedOptions () {
+
+      let ungroup = [];
+      let ungroupObj = {};
+      let type = '';
+
+      Object.keys(this.options).forEach(group => {
+        if (Array.isArray(this.options[group])) {
+          type = 'array';
+          ungroup.push(this.options[group]);
+        } else {
+          type = 'obj';
+          Object.assign(ungroupObj, this.options[group]);
+        }
+      });
+
+      return type === 'array' ? ungroup : ungroupObj;
+
+    },
     inputListeners: function () {
       var vm = this;
       delete this.$listeners.input;

--- a/src/utils/inputMixins.js
+++ b/src/utils/inputMixins.js
@@ -54,7 +54,13 @@ export const inputMixins = {
       }
     },
     optionValue (option, key) {
-      if (Array.isArray(this.options)) {
+      let options = this.options;
+
+      if (this.optgroup) {
+        options = this.ungrouppedOptions;
+      }
+
+      if (Array.isArray(options)) {
         if (typeof option === 'string') {
           return option;
         }
@@ -64,6 +70,7 @@ export const inputMixins = {
       } else {
         return key;
       }
+
     },
   },
 };


### PR DESCRIPTION
optgroup definition: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup

**How to test it:**
Set a new prop to the dropdown:` optgroup = true`

A typical dropdown options looks like:
`["option 1", "option 2", "option 3"]`

If you want to group these options, then you need to wrap it in an object, where the key of the object is the group name, the rest stays the same:

```
{
 "Group 1": ["option 1", "option 2", "option 3"],
 "Group 2": ["option 4", "option 5", "option 6"],
 }
```
 
 This should work on any options format (array of strings, array of objects, object)